### PR TITLE
Create Medicines List container

### DIFF
--- a/okdose-web/assets/locales/en/translation.json
+++ b/okdose-web/assets/locales/en/translation.json
@@ -3,7 +3,7 @@
     "dropdown_description": "Select one of the disease types to calculate its dosage",
     "weight_button": "Calculate",
     "back_button": "Back",
-    "see_more": "See more",
+    "show_more": "Show more",
     "footer_presentation": "OKDOSE is an application that supports the calculation of drug dosage and treatment time for Leishmaniasis, Malaria, Chagas, Rabies, Tuberculosis and Leprosy.",
     "footer_politics": "Politics and regulations",
     "footer_credits": "Credits",

--- a/okdose-web/assets/locales/es/translation.json
+++ b/okdose-web/assets/locales/es/translation.json
@@ -3,7 +3,7 @@
     "dropdown_description": "Selecciona uno de los tipos de enfermedad para calcular su dosificación",
     "weight_button": "Calcular",
     "back_button": "Volver",
-    "see_more": "Ver más",
+    "show_more": "Ver más",
     "footer_presentation": "OKDOSE es una aplicación que apoya el cálculo de la dosificación de medicamentos y tiempo de tratamiento para Leishmaniasis, Malaria, Chagas, Rabia, Tuberculosis y Lepra.",
     "footer_politics": "Políticas y regulaciones",
     "footer_credits": "Créditos",

--- a/okdose-web/components/CardInputWeight.js
+++ b/okdose-web/components/CardInputWeight.js
@@ -1,12 +1,10 @@
-import Button from './common/Button';
 import {useEffect, useState} from 'react';
-import AlertCard from './common/AlertCard';
-import arrowRightIcon from '@icons/arrowRightIcon.svg';
-import PropTypes from 'prop-types';
 import {t} from 'i18next';
-
-const MIN_BOUND = 3;
-const MAX_BOUND = 200;
+import PropTypes from 'prop-types';
+import AlertCard from './common/AlertCard';
+import Button from './common/Button';
+import arrowRightIcon from '@icons/arrowRightIcon.svg';
+import {WEIGHT_RANGE} from '../constants';
 
 function CardInputWeight ({
   titleContent,
@@ -16,7 +14,8 @@ function CardInputWeight ({
   titleCard,
   upperBound,
   lowerBound,
-  disableComponent
+  disableComponent,
+  setWeight
 }) {
   const [inputValue, setInputValue] = useState();
   const [fontStyle, setFontStyle] = useState('');
@@ -30,7 +29,7 @@ function CardInputWeight ({
       setButtonStyle('weight');
       setFontStyle('normal');
     }
-  }, []);
+  }, [disableComponent]);
 
   const inputStyle = {
     error: 'text-strong-red placeholder-strong-red',
@@ -53,6 +52,11 @@ function CardInputWeight ({
     } else {
       setFontStyle('normal');
     }
+  }
+
+  function sendWeight (event) {
+    let value = event.target.value;
+    setWeight(value);
   }
 
   return (
@@ -85,6 +89,7 @@ function CardInputWeight ({
           type={buttonStyle}
           title={t('app_info.weight_button')}
           disable={disableComponent}
+          onClick={sendWeight}
         />
       </div>
     </div>
@@ -95,8 +100,8 @@ CardInputWeight.defaultProps = {
   showCategoryIcon: false,
   showTitleCard: false,
   disableComponent: false,
-  lowerBound: MIN_BOUND,
-  upperBound: MAX_BOUND
+  lowerBound: WEIGHT_RANGE.minBound,
+  upperBound: WEIGHT_RANGE.maxBound
 };
 
 CardInputWeight.propTypes = {

--- a/okdose-web/components/DropdownMenu.js
+++ b/okdose-web/components/DropdownMenu.js
@@ -6,7 +6,7 @@ import byVectorsIcon from '../assets/images/icons/byVectorsIcon.svg';
 import zonosesIcon from '../assets/images/icons/zoonosesIcon.svg';
 import mycobacteriaIcon from '../assets/images/icons/mycobacteriaIcon.svg';
 
-function DropdownMenu ({selectedDisease, inputStatus}) {
+function DropdownMenu ({selectedDisease, inputStatus, setMedicines}) {
   const transmissionTypesIcons = {
     byVectorsIcon: byVectorsIcon,
     mycobacteriaIcon: mycobacteriaIcon,
@@ -25,6 +25,8 @@ function DropdownMenu ({selectedDisease, inputStatus}) {
           title={t(`${transmissionTypes[medium].diseases[disease].name}`)}
           selectedDisease={selectedDisease}
           inputStatus={inputStatus}
+          medicines={transmissionTypes[medium].diseases[disease].medicines}
+          setMedicines={setMedicines}
         />
       ))}
     </Section>

--- a/okdose-web/components/DropdownMenu.js
+++ b/okdose-web/components/DropdownMenu.js
@@ -1,14 +1,12 @@
+import {t} from 'i18next';
+import {transmissionTypes} from '../../okdose/app';
 import Section from './common/Section';
 import DropdownMenuButton from './common/DropdownMenuButton';
-import {useTranslation} from 'react-i18next';
-import {transmissionTypes} from '../../okdose/app';
 import byVectorsIcon from '../assets/images/icons/byVectorsIcon.svg';
 import zonosesIcon from '../assets/images/icons/zoonosesIcon.svg';
 import mycobacteriaIcon from '../assets/images/icons/mycobacteriaIcon.svg';
 
-function DropdownMenu () {
-  const {t} = useTranslation();
-
+function DropdownMenu ({selectedDisease, inputStatus}) {
   const transmissionTypesIcons = {
     byVectorsIcon: byVectorsIcon,
     mycobacteriaIcon: mycobacteriaIcon,
@@ -25,6 +23,8 @@ function DropdownMenu () {
         <DropdownMenuButton
           key={index}
           title={t(`${transmissionTypes[medium].diseases[disease].name}`)}
+          selectedDisease={selectedDisease}
+          inputStatus={inputStatus}
         />
       ))}
     </Section>

--- a/okdose-web/components/common/DisplayCardInformation.js
+++ b/okdose-web/components/common/DisplayCardInformation.js
@@ -1,11 +1,11 @@
-import forwardArrowIcon from '../../assets/images/icons/forwardArrowIcon.svg';
 import PropTypes from 'prop-types';
+import forwardArrowIcon from '../../assets/images/icons/forwardArrowIcon.svg';
 
 function DisplayCardInformation ({
   title,
   description,
   showViewMore,
-  seeMore,
+  showMore,
   showIcon,
   cardIcon,
   type
@@ -22,13 +22,13 @@ function DisplayCardInformation ({
           {showIcon && <img className='pr-3' src={cardIcon} />}
           <h1>{title}</h1>
         </div>
-        <div className='py-5 text-sm'>
-          <p className='whitespace-pre-line'>{description}</p>
+        <div className='text-sm'>
+          <p className='whitespace-pre-line py-3'>{description}</p>
         </div>
       </div>
       {showViewMore && (
         <div className='flex flex-row justify-end items-center text-sm mb-5'>
-          <p>{seeMore}</p>
+          <p data-testid='show-more'>{showMore}</p>
           <img className='pl-1' src={forwardArrowIcon} alt='icon-next' />
         </div>
       )}
@@ -46,7 +46,7 @@ DisplayCardInformation.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   showViewMore: PropTypes.bool,
-  seeMore: PropTypes.string,
+  showMore: PropTypes.string,
   showIcon: PropTypes.bool,
   cardIcon: PropTypes.string,
   type: PropTypes.string.isRequired

--- a/okdose-web/components/common/DropdownMenuButton.js
+++ b/okdose-web/components/common/DropdownMenuButton.js
@@ -1,9 +1,17 @@
 import PropTypes from 'prop-types';
 import rightIcon from '../../assets/images/icons/rightIcon.svg';
 
-function DropdownMenuButton ({title}) {
+function DropdownMenuButton ({title, selectedDisease, inputStatus}) {
+  function handleInput () {
+    selectedDisease(title);
+    inputStatus(false);
+  }
+
   return (
-    <button className='flex flex-row w-full text-neutral-500 p-4 focus:text-indigo-700'>
+    <button
+      className='flex flex-row w-full text-neutral-500 p-4 focus:text-indigo-700'
+      onClick={handleInput}
+    >
       <h6 className='text-xl font-medium text-left'>{title}</h6>
       <div className='ml-auto'>
         <img src={rightIcon} className='min-w-min min-h-min' alt='right-icon' />

--- a/okdose-web/components/common/DropdownMenuButton.js
+++ b/okdose-web/components/common/DropdownMenuButton.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
 import rightIcon from '../../assets/images/icons/rightIcon.svg';
 
-function DropdownMenuButton ({title, selectedDisease, inputStatus}) {
+function DropdownMenuButton ({title, selectedDisease, inputStatus, medicines, setMedicines}) {
   function handleInput () {
     selectedDisease(title);
+    setMedicines(medicines);
     inputStatus(false);
   }
 

--- a/okdose-web/constants/index.js
+++ b/okdose-web/constants/index.js
@@ -7,3 +7,8 @@ export const HEADER_TYPES = {
   welcome: 'welcome',
   home: 'home'
 };
+
+export const WEIGHT_RANGE = {
+  minBound: 3,
+  maxBound: 200
+};

--- a/okdose-web/containers/Home.js
+++ b/okdose-web/containers/Home.js
@@ -10,6 +10,7 @@ import {HEADER_TYPES, WEIGHT_RANGE} from '../constants';
 function Home () {
   const [loadWelcome, setLoadWelcome] = useState(true);
   const [disease, setDisease] = useState(t('app_info.card_selection_title'));
+  const [medicinesList, setMedicinesList] = useState({});
   const [disable, setDisable] = useState(true);
   const [weight, setWeight] = useState(WEIGHT_RANGE.minBound);
 
@@ -30,7 +31,7 @@ function Home () {
           <p className='mb-2 p-5 text-dark-gray text-center'>
             {t('app_info.dropdown_description')}
           </p>
-          <DropdownMenu selectedDisease={setDisease} inputStatus={setDisable} />
+          <DropdownMenu selectedDisease={setDisease} inputStatus={setDisable} setMedicines={setMedicinesList} />
         </aside>
         <main>
           <div className='hidden 2md:block md:px-10 md:pt-16 md:pb-5 lg:pt-28'>
@@ -39,6 +40,7 @@ function Home () {
               weight={weight}
               updateWeight={setWeight}
               inputStatus={disable}
+              medicines={medicinesList}
             />
           </div>
         </main>

--- a/okdose-web/containers/Home.js
+++ b/okdose-web/containers/Home.js
@@ -1,17 +1,17 @@
 import {useEffect, useState} from 'react';
+import {t} from 'i18next';
 import Welcome from '../components/Welcome';
-import DropdownMenu from '../components/DropdownMenu';
-import CardInputWeight from '../components/CardInputWeight';
 import Header from 'components/common/Header';
 import Footer from 'components/common/Footer';
-import {t} from 'i18next';
-import DisplayCardInformation from 'components/common/DisplayCardInformation';
-import timerIcon from '@icons/timerIcon.svg';
-import warningIcon from '@icons/warningIcon.svg';
-import {HEADER_TYPES, CARD_TYPES} from '../constants';
+import DropdownMenu from '../components/DropdownMenu';
+import MainHomeInfo from './MainHomeInfo';
+import {HEADER_TYPES, WEIGHT_RANGE} from '../constants';
 
 function Home () {
   const [loadWelcome, setLoadWelcome] = useState(true);
+  const [disease, setDisease] = useState(t('app_info.card_selection_title'));
+  const [disable, setDisable] = useState(true);
+  const [weight, setWeight] = useState(WEIGHT_RANGE.minBound);
 
   useEffect(() => {
     setTimeout(() => {
@@ -30,52 +30,16 @@ function Home () {
           <p className='mb-2 p-5 text-dark-gray text-center'>
             {t('app_info.dropdown_description')}
           </p>
-          <DropdownMenu />
+          <DropdownMenu selectedDisease={setDisease} inputStatus={setDisable} />
         </aside>
         <main>
           <div className='hidden 2md:block md:px-10 md:pt-16 md:pb-5 lg:pt-28'>
-            <CardInputWeight
-              showCategoryIcon={true}
-              showTitleCard={true}
-              titleCard={t('app_info.card_category_title')}
-              titleContent={t('app_info.card_selection_title')}
-              description={t('app_info.input_weight_description', {
-                weight: '5'
-              })}
-              disableComponent={false}
+            <MainHomeInfo
+              disease={disease}
+              weight={weight}
+              updateWeight={setWeight}
+              inputStatus={disable}
             />
-            <div className='pt-5'>
-              <DisplayCardInformation
-                type={CARD_TYPES.warning}
-                title={t('card_info.warning')}
-                description={t('leishmaniasis.miltefosine.warning_under_10_kg')}
-                showIcon={true}
-                cardIcon={warningIcon}
-              />
-              <DisplayCardInformation
-                type={CARD_TYPES.info}
-                title={t('card_info.dose')}
-                description={'6.0 ml(600mg) IM every day'}
-                showIcon={true}
-                cardIcon={timerIcon}
-              />
-              <DisplayCardInformation
-                type={CARD_TYPES.info}
-                title={t('leishmaniasis.miltefosine.name')}
-                description={
-                  'Amp 1500 mg x 5ml (sb5 + 405 mg) \n Dosage max: (20 mg/kg/day)'
-                }
-                showViewMore={true}
-                seeMore={t('app_info.see_more')}
-              />
-              <DisplayCardInformation
-                type={CARD_TYPES.info}
-                title={t('leishmaniasis.n_metil_glucamine.name')}
-                description={'Vial 300 mg, 60 mg/ml \n (4 mg/kg/day)'}
-                showViewMore={true}
-                seeMore={t('app_info.see_more')}
-              />
-            </div>
           </div>
         </main>
       </div>

--- a/okdose-web/containers/MainHomeInfo.js
+++ b/okdose-web/containers/MainHomeInfo.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import CardInputWeight from '../components/CardInputWeight';
 import MedicinesList from './MedicinesList';
 
-function MainHomeInfo ({disease, weight, updateWeight, inputStatus}) {
+function MainHomeInfo ({disease, weight, updateWeight, inputStatus, medicines}) {
   return (
     <div>
       <CardInputWeight
@@ -18,7 +18,7 @@ function MainHomeInfo ({disease, weight, updateWeight, inputStatus}) {
         setWeight={updateWeight}
       />
       <div className='pt-5'>
-        <MedicinesList selectedDisease={disease} />
+        <MedicinesList medicines={medicines} />
       </div>
     </div>
   );
@@ -29,6 +29,7 @@ MainHomeInfo.propTypes = {
   weight: PropTypes.number.isRequired,
   updateWeight: PropTypes.func,
   inputStatus: PropTypes.bool,
+  medicines: PropTypes.object.isRequired
 };
 
 export default MainHomeInfo;

--- a/okdose-web/containers/MainHomeInfo.js
+++ b/okdose-web/containers/MainHomeInfo.js
@@ -1,0 +1,34 @@
+import {t} from 'i18next';
+import PropTypes from 'prop-types';
+import CardInputWeight from '../components/CardInputWeight';
+import MedicinesList from './MedicinesList';
+
+function MainHomeInfo ({disease, weight, updateWeight, inputStatus}) {
+  return (
+    <div>
+      <CardInputWeight
+        showCategoryIcon={true}
+        showTitleCard={true}
+        titleCard={t('app_info.card_category_title')}
+        titleContent={disease}
+        description={t('app_info.input_weight_description', {
+          weight: weight
+        })}
+        disableComponent={inputStatus}
+        setWeight={updateWeight}
+      />
+      <div className='pt-5'>
+        <MedicinesList selectedDisease={disease} />
+      </div>
+    </div>
+  );
+}
+
+MainHomeInfo.propTypes = {
+  disease: PropTypes.string.isRequired,
+  weight: PropTypes.number.isRequired,
+  updateWeight: PropTypes.func,
+  inputStatus: PropTypes.bool,
+};
+
+export default MainHomeInfo;

--- a/okdose-web/containers/MedicinesList.js
+++ b/okdose-web/containers/MedicinesList.js
@@ -1,0 +1,45 @@
+import {t} from 'i18next';
+import {transmissionTypes} from '../../okdose/app';
+import PropTypes from 'prop-types';
+import DisplayCardInformation from 'components/common/DisplayCardInformation';
+import {CARD_TYPES} from '../constants';
+
+function MedicinesList ({selectedDisease}) {
+  const medicinesList = Object.keys(transmissionTypes).map((medium) =>
+    Object.keys(transmissionTypes[medium].diseases).map(
+      (disease) =>
+        disease.toLowerCase() === selectedDisease.toLowerCase() &&
+        Object.keys(transmissionTypes[medium].diseases[disease].medicines).map(
+          (medicine, index) => (
+            <DisplayCardInformation
+              key={index}
+              type={CARD_TYPES.info}
+              title={t(
+                transmissionTypes[medium].diseases[disease].medicines[medicine]
+                  .name
+              )}
+              description={t(
+                transmissionTypes[medium].diseases[disease].medicines[medicine]
+                  .presentation,
+                {joinArrays: '\n'}
+              )}
+              showViewMore={true}
+              showMore={t('app_info.show_more')}
+            />
+          )
+        )
+    )
+  );
+
+  return (
+  <div>
+    {medicinesList}
+  </div>
+  );
+}
+
+MedicinesList.propTypes = {
+  selectedDisease: PropTypes.string.isRequired
+};
+
+export default MedicinesList;

--- a/okdose-web/containers/MedicinesList.js
+++ b/okdose-web/containers/MedicinesList.js
@@ -1,34 +1,21 @@
 import {t} from 'i18next';
-import {transmissionTypes} from '../../okdose/app';
 import PropTypes from 'prop-types';
 import DisplayCardInformation from 'components/common/DisplayCardInformation';
 import {CARD_TYPES} from '../constants';
 
-function MedicinesList ({selectedDisease}) {
-  const medicinesList = Object.keys(transmissionTypes).map((medium) =>
-    Object.keys(transmissionTypes[medium].diseases).map(
-      (disease) =>
-        disease.toLowerCase() === selectedDisease.toLowerCase() &&
-        Object.keys(transmissionTypes[medium].diseases[disease].medicines).map(
-          (medicine, index) => (
-            <DisplayCardInformation
-              key={index}
-              type={CARD_TYPES.info}
-              title={t(
-                transmissionTypes[medium].diseases[disease].medicines[medicine]
-                  .name
-              )}
-              description={t(
-                transmissionTypes[medium].diseases[disease].medicines[medicine]
-                  .presentation,
-                {joinArrays: '\n'}
-              )}
-              showViewMore={true}
-              showMore={t('app_info.show_more')}
-            />
-          )
-        )
-    )
+function MedicinesList ({medicines}) {
+  const medicinesList = Object.keys(medicines).map((medicine, index) =>
+      <DisplayCardInformation
+      key={index}
+      type={CARD_TYPES.info}
+      title={t(medicines[medicine].name)}
+      description={t(
+        medicines[medicine].presentation,
+        {joinArrays: '\n'}
+      )}
+      showViewMore={true}
+      showMore={t('app_info.show_more')}
+      />
   );
 
   return (
@@ -39,7 +26,7 @@ function MedicinesList ({selectedDisease}) {
 }
 
 MedicinesList.propTypes = {
-  selectedDisease: PropTypes.string.isRequired
+  medicines: PropTypes.object.isRequired
 };
 
 export default MedicinesList;

--- a/okdose-web/tests/MainHomeInfo.test.js
+++ b/okdose-web/tests/MainHomeInfo.test.js
@@ -1,0 +1,168 @@
+import React from 'react';
+import {cleanup, render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import i18n from '../i18n';
+import {I18nextProvider} from 'react-i18next';
+import MainHomeInfo from '../containers/MainHomeInfo';
+
+describe('Test for MainHomeInfo container', () => {
+  // unmount and cleanup DOM after the test is finished.
+  afterEach(cleanup);
+
+  jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useState: jest.fn()
+  }))
+  const setWeight = jest.fn()
+
+  describe('MainHomeInfo only renders the CardInputWeight when disease is not selected',()=>{
+    const disable = true;
+
+    test('It renders correctly English translations', () => {
+      i18n.changeLanguage('en');
+      render(
+        <I18nextProvider i18n={i18n}>
+          <MainHomeInfo
+            disease={'Selection'}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+        </I18nextProvider>
+      );
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('en').translation.app_info.card_selection_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('en').translation.app_info.card_category_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.queryByText(
+          i18n.getDataByLanguage('en').translation.app_info.show_more
+        )
+      ).not.toBeInTheDocument();
+    })
+
+    test('It renders correctly Spanish translations', () => {
+      i18n.changeLanguage('es');
+      render(
+        <I18nextProvider i18n={i18n}>
+          <MainHomeInfo
+            disease={'Selección'}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+        </I18nextProvider>
+      );
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('es').translation.app_info.card_selection_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('es').translation.app_info.card_category_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.queryByText(
+          i18n.getDataByLanguage('es').translation.app_info.show_more
+        )
+      ).not.toBeInTheDocument();
+    })
+
+    test('The input is disabled', () => {
+      render(
+          <MainHomeInfo
+            disease={'Selección'}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+      );
+      expect(screen.getByLabelText('weight-input')).toBeDisabled()
+    })
+  });
+
+  describe('MainHomeInfo renders the CardInputWeight and MedicinesList components when disease is selected',()=>{
+    const disable = false;
+
+    test('It renders correctly English translations', () => {
+      const disease = 'Leishmaniasis';
+
+      i18n.changeLanguage('en');
+      const { getAllByText } = render(
+        <I18nextProvider i18n={i18n}>
+          <MainHomeInfo
+            disease={disease}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+        </I18nextProvider>
+      );
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('en').translation.app_info.card_category_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('en').translation.leishmaniasis.name
+        )
+      ).toBeDefined();
+      const items = getAllByText('Show more');
+      const firstItem = items[0];
+
+      expect(firstItem).toBeInTheDocument();
+    })
+
+    test('It renders correctly Spanish translations', () => {
+      const disease = 'Leishmaniasis';
+
+      i18n.changeLanguage('es');
+      const { getAllByText } = render(
+        <I18nextProvider i18n={i18n}>
+          <MainHomeInfo
+            disease={disease}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+        </I18nextProvider>
+      );
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('es').translation.app_info.card_category_title
+        )
+      ).toBeDefined();
+      expect(
+        screen.getByText(
+          i18n.getDataByLanguage('es').translation.leishmaniasis.name
+        )
+      ).toBeDefined();
+      const items = getAllByText('Ver más');
+      const firstItem = items[0];
+
+      expect(firstItem).toBeInTheDocument();
+    })
+
+    test('The input is enabled', () => {
+      const disease = 'Leishmaniasis';
+      render(
+          <MainHomeInfo
+            disease={disease}
+            weight={50}
+            updateWeight={setWeight}
+            inputStatus={disable}
+          />
+      );
+      expect(screen.getByLabelText('weight-input')).toBeEnabled()
+    })
+  });
+});

--- a/okdose-web/tests/MainHomeInfo.test.js
+++ b/okdose-web/tests/MainHomeInfo.test.js
@@ -3,6 +3,7 @@ import {cleanup, render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import i18n from '../i18n';
 import {I18nextProvider} from 'react-i18next';
+import {transmissionTypes} from '../../okdose/app';
 import MainHomeInfo from '../containers/MainHomeInfo';
 
 describe('Test for MainHomeInfo container', () => {
@@ -27,6 +28,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={{}}
           />
         </I18nextProvider>
       );
@@ -56,6 +58,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={{}}
           />
         </I18nextProvider>
       );
@@ -83,6 +86,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={{}}
           />
       );
       expect(screen.getByLabelText('weight-input')).toBeDisabled()
@@ -91,6 +95,7 @@ describe('Test for MainHomeInfo container', () => {
 
   describe('MainHomeInfo renders the CardInputWeight and MedicinesList components when disease is selected',()=>{
     const disable = false;
+    const medicinesList = transmissionTypes.byVectors.diseases.leishmaniasis.medicines;
 
     test('It renders correctly English translations', () => {
       const disease = 'Leishmaniasis';
@@ -103,6 +108,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={medicinesList}
           />
         </I18nextProvider>
       );
@@ -133,6 +139,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={medicinesList}
           />
         </I18nextProvider>
       );
@@ -160,6 +167,7 @@ describe('Test for MainHomeInfo container', () => {
             weight={50}
             updateWeight={setWeight}
             inputStatus={disable}
+            medicines={medicinesList}
           />
       );
       expect(screen.getByLabelText('weight-input')).toBeEnabled()

--- a/okdose-web/tests/MedicinesList.test.js
+++ b/okdose-web/tests/MedicinesList.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import {cleanup, render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import i18n from '../i18n';
+import {I18nextProvider} from 'react-i18next';
+import MedicinesList from '../containers/MedicinesList';
+
+describe('Test for MedicinesList container', () => {
+  // unmount and cleanup DOM after the test is finished.
+  afterEach(cleanup);
+
+  test('MedicinesList container renders with English translations', () => {
+    i18n.changeLanguage('en');
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MedicinesList selectedDisease={'Leishmaniasis'}/>,
+      </I18nextProvider>
+    );
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('en').translation.leishmaniasis.n_metil_glucamine.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('en').translation.leishmaniasis.sodium_stibogluconate.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('en').translation.leishmaniasis.pentamidine_isethionate.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('en').translation.leishmaniasis.miltefosine.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('en').translation.leishmaniasis.amphotericin_b_liposomal.name
+      )
+    ).toBeDefined();
+  });
+
+  test('MedicinesList container renders with Spanish translations', () => {
+    i18n.changeLanguage('es');
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MedicinesList selectedDisease={'Leishmaniasis'}/>,
+      </I18nextProvider>
+    );
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('es').translation.leishmaniasis.n_metil_glucamine.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('es').translation.leishmaniasis.sodium_stibogluconate.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('es').translation.leishmaniasis.pentamidine_isethionate.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('es').translation.leishmaniasis.miltefosine.name
+      )
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        i18n.getDataByLanguage('es').translation.leishmaniasis.amphotericin_b_liposomal.name
+      )
+    ).toBeDefined();
+  });
+});

--- a/okdose-web/tests/MedicinesList.test.js
+++ b/okdose-web/tests/MedicinesList.test.js
@@ -3,17 +3,23 @@ import {cleanup, render, screen} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import i18n from '../i18n';
 import {I18nextProvider} from 'react-i18next';
+import {transmissionTypes} from '../../okdose/app';
 import MedicinesList from '../containers/MedicinesList';
 
 describe('Test for MedicinesList container', () => {
   // unmount and cleanup DOM after the test is finished.
   afterEach(cleanup);
 
+  const medicinesList = transmissionTypes.byVectors.diseases.leishmaniasis.medicines;
+
   test('MedicinesList container renders with English translations', () => {
     i18n.changeLanguage('en');
     render(
       <I18nextProvider i18n={i18n}>
-        <MedicinesList selectedDisease={'Leishmaniasis'}/>,
+        <MedicinesList
+          selectedDisease={'Leishmaniasis'}
+          medicines={medicinesList}
+        />,
       </I18nextProvider>
     );
     expect(
@@ -47,7 +53,10 @@ describe('Test for MedicinesList container', () => {
     i18n.changeLanguage('es');
     render(
       <I18nextProvider i18n={i18n}>
-        <MedicinesList selectedDisease={'Leishmaniasis'}/>,
+        <MedicinesList
+          selectedDisease={'Leishmaniasis'}
+          medicines={medicinesList}
+        />,
       </I18nextProvider>
     );
     expect(


### PR DESCRIPTION
## Description

The home page was structured with a main container to render the weight input and the medicines lists. Also, the configuration to connect the sibling components was done. The disable prop for the weight input was set to change from the Dropdown menu

The tests for the containers created were added. 

Now in the app, the medicines with their description are rendered when clicking the disease in the Dropdown menu and the weight input is enabled:

![image](https://user-images.githubusercontent.com/112585154/222283586-847e6926-1779-4678-b3e8-2aa1a43b436b.png)


Fixes #71 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
